### PR TITLE
Please pull to update grails-spring-security-openid plugin to match core

### DIFF
--- a/SpringSecurityOpenidGrailsPlugin.groovy
+++ b/SpringSecurityOpenidGrailsPlugin.groovy
@@ -29,9 +29,9 @@ import org.springframework.security.openid.OpenIDAuthenticationFilter
 
 class SpringSecurityOpenidGrailsPlugin {
 
-	String version = '1.0'
+	String version = '1.1'
 	String grailsVersion = '1.2.3 > *'
-	Map dependsOn = ['springSecurityCore': '1.0 > *']
+	Map dependsOn = ['springSecurityCore': '1.1 > *']
 	List pluginExcludes = [
 		'grails-app/domain/**',
 		'docs/**',

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -20,7 +20,7 @@ grails.project.dependency.resolution = {
 	}
 
 	dependencies {
-		runtime('org.springframework.security:org.springframework.security.openid:3.0.3.RELEASE') {
+		runtime('org.springframework.security:org.springframework.security.openid:3.0.4.RELEASE') {
 			excludes 'com.springsource.javax.servlet',
 			         'com.springsource.org.aopalliance',
 			         'com.springsource.org.apache.commons.logging',


### PR DESCRIPTION
grails-spring-security-core is using spring security 3.0.4 - openid should be bumped to do so as well.
